### PR TITLE
Add Method to Retrieve Webhook IPs in Webhook Resource

### DIFF
--- a/src/Resources/Webhooks.php
+++ b/src/Resources/Webhooks.php
@@ -142,6 +142,35 @@ class Webhooks
     }
 
     /**
+     * Get a list of webhook IPs.
+     *
+     * ## Usage
+     * ```php
+     * $result = $client->webhooks()->ips();
+     *
+     * foreach ($result["ips"] as $ip) {
+     *     echo $ip; // string
+     * }
+     *
+     * $result["ips"][0]; // "189.51.60.9"
+     * $result["ips"][1]; // "138.97.124.129"
+     * $result["ips"][2]; // "177.71.136.66"
+     * ```
+     *
+     * @link https://developers.openpix.com.br/api#tag/webhook/paths/~1api~1v1~1webhook~1ips/get
+     *
+     * @return array<string, mixed>
+     */
+    public function ips(): array
+    {
+        $request = (new Request())
+            ->method("GET")
+            ->path("/api/v1/webhook/ips");
+
+        return $this->requestTransport->transport($request);
+    }
+
+    /**
      * Validate webhook signature.
      *
      * Every Webhook request has the header `x-webhook-signature` which is the signature

--- a/tests/Resources/WebhooksTest.php
+++ b/tests/Resources/WebhooksTest.php
@@ -73,6 +73,26 @@ final class WebhooksTest extends TestCase
         $this->assertSame(["webhook" => []], $result);
     }
 
+    public function testIps(): void
+    {
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame("GET", $request->getMethod());
+                $this->assertSame("/api/v1/webhook/ips", $request->getPath());
+                $this->assertSame(null, $request->getBody());
+                $this->assertSame([], $request->getQueryParams());
+
+                return ["ips" => []];
+            });
+
+        $webhooks = new Webhooks($requestTransportMock);
+        $result = $webhooks->ips();
+
+        $this->assertSame(["ips" => []], $result);
+    }
+
     public function testIsWebhookValidReturnsTrueWithValidWebhook(): void
     {
         $webhooks = new Webhooks($this->createStub(RequestTransport::class));


### PR DESCRIPTION
This pull request adds a new method `ips()` to the `Webhook.php` resource in the `woovibr/php-sdk`, allowing users to retrieve a list of webhook IPs. This enhancement aligns with the [OpenPix API documentation](https://developers.openpix.com.br/api#tag/webhook/paths/~1api~1v1~1webhook~1ips/get) and provides a simple way for developers to access and utilize webhook IP information in their projects.

## Summary of Changes:
1. New Method Added:

    - `ips()`: A method that sends a GET request to the `/api/v1/webhook/ips` endpoint and returns an array of IPs. 
    
    #### Usage Example:
    ```php
    $result = $client->webhooks()->ips();

    foreach ($result["ips"] as $ip) {
        echo $ip; // string
    }

    // Sample output:
    $result["ips"][0]; // "189.51.60.9"
    $result["ips"][1]; // "138.97.124.129"
    $result["ips"][2]; // "177.71.136.66"
    ```

2. Unit Test Added:

    - A test method `testIps()` was created to verify the behavior of the `ips()` method, ensuring the correct request is made and the response structure is as expected.
    #### Test Highlights:
    - Verifies that the `ips()` method sends a `GET` request to `/api/v1/webhook/ips`.
    - Checks that the response matches the expected structure.

## Motivation:

Currently, the SDK does not include a method for retrieving webhook IPs, which limits the functionality and utility for developers working with webhook security or validation. This addition enhances the SDK's capabilities and aligns with API documentation, providing better integration options for users.

## Testing:

The method was tested using a unit test (`testIps()`), which confirms:

- The correct HTTP method and endpoint are used.
- The response structure follows the expected output format.

## Potential Impact:

This addition is non-breaking and should integrate seamlessly with existing projects. Users can immediately benefit from this feature without any changes to their current implementation.

## Additional Notes:

- Documentation and inline examples were provided in the `ips()` method for ease of use.
- No dependencies were introduced.
