### PR TITLE
Add Partners Resource to PHP-SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [1.1.5](https://github.com/Open-Pix/php-sdk/compare/v1.1.4...v1.1.5) (2024-11-25)
+## [1.1.5](https://github.com/Open-Pix/php-sdk/compare/v1.1.4...v1.1.5) (2024-11-26)
 
 ### Partners Resource
 
-* Partners Resource has been added...
+* Partners Resource has been added.
+
 
 ## [1.1.4](https://github.com/Open-Pix/php-sdk/compare/v1.1.3...v1.1.4) (2024-11-19)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace OpenPix\PhpSdk;
 use OpenPix\PhpSdk\RequestTransport;
 use OpenPix\PhpSdk\Resources\Charges;
 use OpenPix\PhpSdk\Resources\Customers;
+use OpenPix\PhpSdk\Resources\Partners;
 use OpenPix\PhpSdk\Resources\Transactions;
 use OpenPix\PhpSdk\Resources\Subscriptions;
 use OpenPix\PhpSdk\Resources\Webhooks;
@@ -112,5 +113,13 @@ class Client
     public function webhooks(): Webhooks
     {
         return new Webhooks($this->requestTransport);
+    }
+
+    /**
+     * Returns operations for the `Partners` resource.
+     */
+    public function partners(): Partners
+    {
+        return new Partners($this->requestTransport);
     }
 }

--- a/src/Resources/Partners.php
+++ b/src/Resources/Partners.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace OpenPix\PhpSdk\Resources;
+
+use OpenPix\PhpSdk\Paginator;
+use OpenPix\PhpSdk\Request;
+use OpenPix\PhpSdk\RequestTransport;
+
+/**
+ * Operations on partners. To use this section of the SDK you need to request access to OpenPix.
+ *
+ * @link https://developers.openpix.com.br/api#tag/partner-(request-access)
+ */
+class Partners
+{
+    /**
+     * Used to send HTTP requests to partners API.
+     *
+     * @var RequestTransport
+     */
+    private $requestTransport;
+
+    /**
+     * Create a new Partners instance.
+     *
+     * @param RequestTransport $requestTransport Used to send HTTP requests to partners API.
+     */
+    public function __construct(RequestTransport $requestTransport)
+    {
+        $this->requestTransport = $requestTransport;
+    }
+
+    /**
+     * Get every preregistration that is managed by you. {@see Paginator}.
+     *
+     * ## Usage
+     * ```php
+     * $paginator = $client->partners()->list();
+     *
+     * foreach ($paginator as $result) {
+     *      foreach ($result["preRegistrations"] as $partner) {
+     *          $partner["preRegistration"]; // array
+     *          $partner["preRegistration"]["name"]; // string
+     *          $partner["user"]; // array
+     *          $partner["user"]["firstName"]; // string
+     *          $partner["user"]["email"]; // string
+     *          $partner["company"]["name"]; // string
+     *          // and more fields...
+     *      }
+     * }
+     * ```
+     *
+     * @link https://developers.openpix.com.br/api#tag/partner-(request-access)/paths/~1api~1v1~1partner~1company/get
+     *
+     * @return Paginator with results from API.
+     */
+    public function list(): Paginator
+    {
+        $request = (new Request())
+            ->method("GET")
+            ->path("/api/v1/partner/company");
+
+        return new Paginator($this->requestTransport, $request);
+    }
+
+    /**
+     * Get a specific preregistration via taxID param.
+     *
+     * ```php
+     * $result = $client->partners()->getOne("taxID");
+     *
+     * $result["preRegistration"]["preRegistration"]["name"]; // string
+     * $result["preRegistration"]["user"]["firstName"]; // string
+     * $result["preRegistration"]["company"]["name"]; // string
+     * $result["preRegistration"]["account"]["clientId"]; // string
+     * // and more fields...
+     * ```
+     *
+     * @link https://developers.openpix.com.br/api#tag/partner-(request-access)/paths/~1api~1v1~1partner~1company~1%7BtaxID%7D/get
+     *
+     * @param string $taxID Tax ID.
+     *
+     * @return array<string, mixed> Result from API.
+     */
+    public function getOne(string $taxID): array
+    {
+        $request = (new Request())
+            ->method("GET")
+            ->path("/api/v1/partner/company/" . $taxID);
+
+        return $this->requestTransport->transport($request);
+    }
+
+    /**
+     * Create a preregistration with a partner reference (your company)
+     *
+     * ```php
+     * $result = $client->partners()->create([
+     *      "preRegistration" => [
+     *         "name" => "Example LLC", // Name of partner company. Required. (string).
+     *         "website" => "", // Website of the partner company. (string).
+     *         "taxID" => [
+     *           "taxID" => "11111111111111" // Tax ID of the partner company. Required. (string).
+     *           "type" => "BR:CNPJ" // Type of the Tax ID of the partner company. Required. (string).
+     *         ],
+     *      ],
+     *      "user" => [
+     *        "firstName" => "John", // First Name of the partner. Required. (string).
+     *        "lastName" => "Doe", // Last Name of the partner. Required. (string).
+     *        "email" => "johndoe@examplellc.com", // E-mail of the partner. Required. (string).
+     *        "phone" => "+5511912345678", // Phone number of the partner. Required. (string).
+     *      ],
+     *      // and more fields...
+     * ]);
+     *
+     * $result["preRegistration"]["name"]; // string
+     * $result["preRegistration"]["website"]; // string
+     * $result["preRegistration"]["taxID"]["taxID"]; // string
+     * $result["preRegistration"]["taxID"]["type"]; // string
+     *
+     * $result["user"]["firstName"]; // string
+     * $result["user"]["lastName"]; // string
+     * $result["user"]["email"]; // string
+     * $result["user"]["phone"]; // string
+     * ```
+     *
+     * @link https://developers.openpix.com.br/api#tag/partner-(request-access)/paths/~1api~1v1~1partner~1company/post
+     *
+     * @param array<string, mixed> $data Partner data.
+     *
+     * @return array<string, mixed> Result from API.
+     */
+    public function create(array $data): array
+    {
+        $request = (new Request())
+            ->method("POST")
+            ->path("/api/v1/partner/company")
+            ->body($data);
+
+        return $this->requestTransport->transport($request);
+    }
+
+    /**
+     * Create a new application to some of your preregistration's company.
+     *
+     * ```php
+     * $result = $client->partners()->createApp([
+     *      "application" => [
+     *         "name" => "MyAPIAccess", // Name of app. Required. (string).
+     *         "type" => "API", // Type of app. Enum: "API", "PLUGIN", "ORACLE". Required. (string).
+     *      ],
+     *      "taxID" => [
+     *        "taxID" => "65914571000187", // Tax ID of the partner company. (string).
+     *        "type" => "BR:CNPJ",
+     *      ],
+     *      // and more fields...
+     * ]);
+     *
+     * $app = $result["application"];
+     *
+     * $app["name"]; // string
+     * $app["isActive"]; // boolean
+     * $app["type"]; // string
+     * $app["clientId"]; // string
+     * $app["clientSecret"]; // string
+     * ```
+     *
+     * @link https://developers.openpix.com.br/api#tag/partner-(request-access)/paths/~1api~1v1~1partner~1application/post
+     *
+     * @param array<string, mixed> $data Partner data.
+     *
+     * @return array<string, mixed> Result from API.
+     */
+    public function createApp(array $data): array
+    {
+        $request = (new Request())
+            ->method("POST")
+            ->path("/api/v1/partner/application")
+            ->body($data);
+
+        return $this->requestTransport->transport($request);
+    }
+}

--- a/tests/Resources/PartnersTest.php
+++ b/tests/Resources/PartnersTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Resources;
+
+use OpenPix\PhpSdk\Request;
+use OpenPix\PhpSdk\RequestTransport;
+use OpenPix\PhpSdk\Resources\Partners;
+use PHPUnit\Framework\TestCase;
+
+final class PartnersTest extends TestCase
+{
+    public function testList(): void
+    {
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+
+        $partners = new Partners($requestTransportMock);
+
+        $pagedRequest = $partners->list()->getPagedRequest();
+
+        $this->assertSame($pagedRequest->getPath(), "/api/v1/partner/company");
+        $this->assertSame($pagedRequest->getMethod(), "GET");
+        $this->assertSame($pagedRequest->getBody(), null);
+    }
+
+    public function testGetOne(): void
+    {
+        $taxID = "11111111111111";
+        $partner = [
+            "preRegistration" => [
+                "preRegistration" => [
+                    "name" => "string",
+                ],
+                "user" => [
+                    "firstName" => "string",
+                ],
+            ],
+        ];
+
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->willReturnCallback(function (Request $request) use ($taxID, $partner) {
+                $this->assertSame("GET", $request->getMethod());
+                $this->assertSame("/api/v1/partner/company/" . $taxID, $request->getPath());
+                $this->assertSame($request->getBody(), null);
+                $this->assertSame($request->getQueryParams(), []);
+
+                return $partner;
+            });
+
+        $partners = new Partners($requestTransportMock);
+
+        $result = $partners->getOne($taxID);
+
+        $this->assertSame($result, $partner);
+    }
+
+    public function testCreate(): void
+    {
+        $partner = [
+            "preRegistration" => [
+                "name" => "Example LLC",
+            ],
+            "user" => [
+                "firstName" => "John",
+            ],
+        ];
+
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->willReturnCallback(function (Request $request) use ($partner) {
+                $this->assertSame("POST", $request->getMethod());
+                $this->assertSame("/api/v1/partner/company", $request->getPath());
+                $this->assertSame($request->getBody(), $partner);
+                $this->assertSame($request->getQueryParams(), []);
+
+                return $partner;
+            });
+
+        $partners = new Partners($requestTransportMock);
+
+        $result = $partners->create($partner);
+
+        $this->assertSame($result, $partner);
+    }
+
+    public function testCreateApp(): void
+    {
+        $partner = [
+            "application" => [
+                "name" => "Example LLC",
+                "type" => "API",
+            ],
+            "taxID" => [
+                "taxID" => "65914571000187",
+                "type" => "BR:CNPJ",
+            ],
+        ];
+
+        $requestTransportMock = $this->createMock(RequestTransport::class);
+        $requestTransportMock->expects($this->once())
+            ->method("transport")
+            ->willReturnCallback(function (Request $request) use ($partner) {
+                $this->assertSame("POST", $request->getMethod());
+                $this->assertSame("/api/v1/partner/application", $request->getPath());
+                $this->assertSame($request->getBody(), $partner);
+                $this->assertSame($request->getQueryParams(), []);
+
+                return $partner;
+            });
+
+        $partners = new Partners($requestTransportMock);
+
+        $result = $partners->createApp($partner);
+
+        $this->assertSame($result, $partner);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new resource, Partners, to the PHP-SDK, expanding its functionality to include operations related to partner management. The goal is to align with OpenPix’s API capabilities and support use cases involving partner pre-registrations and applications.

### Summary of Changes
1. Partners Class Implementation:
    - Methods added:
      - `list`: List all partner pre-registrations.
      - `getOne`: Retrieve details of a specific partner by Tax ID.
      - `create`: Create new partner pre-registrations.
      - `createApp`: Create applications linked to pre-registrations.
    - Includes clear PHPDoc comments to ensure ease of understanding and integration.

2. Unit Tests:
    - To ensure reliability and maintain SDK standards, the following unit tests have been added for the Partners resource:
      - `testList`: Verifies the correct API path and method for listing preregistrations.
      - `testGetOne`: Ensures fetching a specific preregistration works as expected.
      - `testCreate`: Tests the creation of a new preregistration.
      - `testCreateApp`: Validates the creation of a new application.

### Motivation
This enhancement is designed to make the SDK more versatile, providing developers with tools to handle partner-related workflows seamlessly.