### PR TITLE
Update supported PHP versions in code-quality.yml

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php-version: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Description

This pull request updates the php-version configuration in the .github/workflows/code-quality.yml file to reflect the current state of PHP development and support.

#### Changed from:

```yaml
php-version: [7.3, 7.4, 8.0, 8.1, 8.2]  
```

#### Changed to:

```yaml
php-version: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
```
--- 
At this point in time:

- PHP 8.0 and earlier versions have reached their End of Life (EOL) and no longer receive updates or support.
- PHP 8.1 is in security fixes only mode, addressing critical vulnerabilities but not receiving general updates.
- PHP 8.2 and above are in active development, receiving new features and regular updates.

**Reference:** This information is based on the PHP lifecycle data available at the [Setup PHP Action](https://github.com/marketplace/actions/setup-php-action#tada-php-support).

These updates align the project with the current PHP ecosystem and ensure future compatibility.